### PR TITLE
Add option to generate spritemap without <use> elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ Whether to delete the chunk after it's been emitted by webpack.
 ### `generateTitle` - `true`
 Whether to generate a `<title>` element containing the filename if no title is provided in the SVG.
 
+### `includeUse` - `true`
+Whether to include `<use>` element within the generated spritemap to allow referencing symbols from CSS
+
 ## SVG4Everybody
 > [SVG for Everybody](https://github.com/jonathantneal/svg4everybody) adds [SVG External Content](http://css-tricks.com/svg-sprites-use-better-icon-fonts/##Browser+Support) support to [all browsers](http://caniuse.com/svg).
 

--- a/lib/generate-svg.js
+++ b/lib/generate-svg.js
@@ -8,7 +8,8 @@ module.exports = (files = [], options = {}) => {
     options = merge({
         gutter: 0,
         prefix: '',
-        generateTitle: true
+        generateTitle: true,
+        includeUse: true
     }, options);
 
     // No point in generating when there are no files
@@ -30,7 +31,9 @@ module.exports = (files = [], options = {}) => {
 
     // Add namespaces
     svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-    svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    if ( options.includeUse ) {
+        svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+    }
 
     // Add symbol for each file
     files.forEach((file) => {
@@ -92,23 +95,27 @@ module.exports = (files = [], options = {}) => {
 
         svg.appendChild(symbol);
 
-        // Generate <use> elements within spritemap to allow usage within CSS
-        const use = XMLDoc.createElement('use');
-        use.setAttribute('xlink:href', `#${validId}`);
-        use.setAttribute('x', '0');
-        use.setAttribute('y', sizes.height.reduce((a, b) => a + b, 0) + (sizes.height.length * options.gutter));
-        use.setAttribute('width', width.toString());
-        use.setAttribute('height', height.toString());
-        svg.appendChild(use);
+        if ( options.includeUse ) {
+            // Generate <use> elements within spritemap to allow usage within CSS
+            const use = XMLDoc.createElement('use');
+            use.setAttribute('xlink:href', `#${validId}`);
+            use.setAttribute('x', '0');
+            use.setAttribute('y', sizes.height.reduce((a, b) => a + b, 0) + (sizes.height.length * options.gutter));
+            use.setAttribute('width', width.toString());
+            use.setAttribute('height', height.toString());
+            svg.appendChild(use);
 
-        // Update sizes
-        sizes.width.push(width);
-        sizes.height.push(height);
+            // Update sizes
+            sizes.width.push(width);
+            sizes.height.push(height);
+        }
     });
 
-    // Add width/height to spritemap
-    svg.setAttribute('width', Math.max.apply(null, sizes.width).toString());
-    svg.setAttribute('height', (sizes.height.reduce((a, b) => a + b, 0) + ((sizes.height.length - 1) * options.gutter)).toString());
+    if (options.includeUse) {
+        // Add width/height to spritemap
+        svg.setAttribute('width', Math.max.apply(null, sizes.width).toString());
+        svg.setAttribute('height', (sizes.height.reduce((a, b) => a + b, 0) + ((sizes.height.length - 1) * options.gutter)).toString());
+    }
 
     return XMLSerializer.serializeToString(svg);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,8 @@ module.exports = class SVGSpritemapPlugin {
             glob: {},
             chunk: 'spritemap',
             deleteChunk: true,
-            generateTitle: true
+            generateTitle: true,
+            includeUse: true
         }, options);
 
         // Sanitize options
@@ -138,7 +139,8 @@ module.exports = class SVGSpritemapPlugin {
             const spritemap = generateSVG(this.files, {
                 prefix: this.options.prefix,
                 gutter: this.options.gutter,
-                generateTitle: this.options.generateTitle
+                generateTitle: this.options.generateTitle,
+                includeUse: this.options.includeUse
             });
 
             if ( !spritemap ) {

--- a/tests/generate-svg.test.js
+++ b/tests/generate-svg.test.js
@@ -62,3 +62,13 @@ it('Throws when the width/height of an SVG can not be calculated', () => {
         ], OPTIONS);
     }).toThrow();
 });
+
+it('Generates without use tag when \'options.includeUse\' is \'false\'', () => {
+    const output = fs.readFileSync(path.join(__dirname, 'output/svg/no-use.svg'), 'utf-8').trim();
+
+    expect(generateSVG([
+        path.join(__dirname, 'input/svg/single.svg')
+    ], Object.assign({}, OPTIONS, {
+        includeUse: false
+    }))).toBe(output);
+})

--- a/tests/output/svg/no-use.svg
+++ b/tests/output/svg/no-use.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg"><symbol id="sprite-single" viewBox="0 0 24 24"><title>single</title>
+    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/>
+</symbol></svg>


### PR DESCRIPTION
Hello, thank you for your plugin, it serves my purposes very nicely :)

One issue I had though is, that I do not need the `<use>` elements it generates, because I cache the file and inject it into body and then reference the symbols when needed by `<svg><use xlink:href="#symbol" /></svg>`

So I have added an option `includeUse` to disable this behavior and managed to save over 50 kB on fairly large set of ~700 simple svg icons.

The default behavior stayed the same, so only minor version bump is necessary. Let me know if you need some changes or improvements!