### PR TITLE
Use without size

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -43,6 +43,7 @@ new SVGSpritemapPlugin(string | string[], {
             title?: boolean,
             symbol?: boolean | string,
             use?: boolean,
+            useWithSizes?: boolean,
             view?: boolean | string
         }
     },
@@ -122,6 +123,9 @@ Whether to include a `<symbol>` element for each sprite within the generated spr
 
 #### `sprite.generate.use` - `false`
 Whether to include a `<use>` element for each sprite within the generated spritemap to allow referencing symbols from CSS.
+
+#### `sprite.generate.useWithSizes` - `true`
+Whether to add 'height' and 'width' to `<svg>`
 
 #### `sprite.generate.view` - `false`
 Whether to include a `<view>` element for each sprite within the generated spritemap to allow referencing via [fragment identifiers](https://css-tricks.com/svg-fragment-identifiers-work/). Passing a string will use the value as a postfix for the `id` attribute.

--- a/lib/generate-svg.js
+++ b/lib/generate-svg.js
@@ -14,6 +14,7 @@ module.exports = (files = [], options = {}) => {
             title: true,
             symbol: true,
             use: false,
+            useWithSizes: true,
             view: false
         },
         svgo: {}
@@ -214,7 +215,7 @@ module.exports = (files = [], options = {}) => {
                 sizes.height.push(height);
             });
 
-            if ( options.generate.use ) {
+            if ( options.generate.use && options.generate.useWithSizes) {
                 // Add width/height to spritemap
                 svg.setAttribute('width', Math.max.apply(null, sizes.width).toString());
                 svg.setAttribute('height', (sizes.height.reduce((a, b) => a + b, 0) + ((sizes.height.length - 1) * options.gutter)).toString());

--- a/lib/options-validator.js
+++ b/lib/options-validator.js
@@ -44,6 +44,7 @@ module.exports = (pattern, options = {}) => {
                         Joi.string()
                     ]),
                     use: Joi.boolean(),
+                    useWithSizes: Joi.boolean(),
                     view: Joi.alternatives([
                         Joi.boolean(),
                         Joi.string()

--- a/tests/generate-svg.test.js
+++ b/tests/generate-svg.test.js
@@ -70,6 +70,19 @@ it(`Generates with <use> tag when 'options.generate.use' is 'true'`, async () =>
 
     expect(svg).toBe(output);
 });
+it(`Generates with <use> tag without sizes when 'options.generate.use' is 'true' and 'options.generate.useWithSizes' is 'false'`, async () => {
+    const output = fs.readFileSync(path.join(__dirname, 'output/svg/with-use-no-sizes.svg'), 'utf-8').trim();
+    const svg = await generateSVG([
+        path.join(__dirname, 'input/svg/single.svg')
+    ], {
+        generate: {
+            use: true,
+            useWithSizes: false
+        }
+    });
+
+    expect(svg).toBe(output);
+});
 
 it(`Generates with <view> tag when 'options.generate.view' is 'true'`, async () => {
     const output = fs.readFileSync(path.join(__dirname, 'output/svg/with-view.svg'), 'utf-8').trim();

--- a/tests/output/svg/with-use-no-sizes.svg
+++ b/tests/output/svg/with-use-no-sizes.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><symbol id="single" viewBox="0 0 24 24"><title>single</title><path d="M21 7L9 19l-5.5-5.5 1.41-1.41L9 16.17 19.59 5.59 21 7z"/></symbol><use xlink:href="#single" x="0" y="0" width="24" height="24"/></svg>


### PR DESCRIPTION
Ability to generate use without sizes in the `<svg>` that can make fail SVG sprite in CSS with ref.