### PR TITLE
Allow for attributes on root svg element

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -40,6 +40,9 @@ new SVGSpritemapPlugin(string | string[], {
         svgo?: boolean | object
     },
     sprite?: {
+        attributes?: {
+          id?: string
+        },
         prefix?: string | function(file) | false,
         gutter?: number | false,
         generate?: {
@@ -113,6 +116,12 @@ Options object to pass to [`SVG Optimizer`](http://npmjs.com/package/svgo).
 
 ### Sprite
 The `sprite` object contains the configuration for the generated sprites in the output spritemap.
+
+#### `sprite.attributes` - `{}`
+Extra attributes for root svg element.
+
+#### `sprite.attributes.id` - `undefined`
+Id attribute for root svg element.
 
 #### `sprite.prefix` – `'sprite-'`
 Prefix added to sprite `id` in the spritemap. It will be used for the class/spritename in the generated styles as well. It's possible to pass a function for more advanced situations, the full path to the current sprite will be passed as the first argument.

--- a/lib/generate-svg.js
+++ b/lib/generate-svg.js
@@ -10,6 +10,7 @@ const generateSpritePrefix = require('./helpers/generate-sprite-prefix');
 module.exports = (files = [], options = {}) => {
     options = merge({
         sprite: {
+            attributes: {},
             gutter: 0,
             prefix: '',
             generate: {
@@ -70,6 +71,10 @@ module.exports = (files = [], options = {}) => {
         svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
         if ( options.sprite.generate.use ) {
             svg.setAttribute('xmlns:xlink', 'http://www.w3.org/1999/xlink');
+        }
+
+        if (options.sprite.attributes.id && typeof options.sprite.attributes.id === 'string') {
+          svg.setAttribute('id', options.sprite.attributes.id)
         }
 
         Promise.all(files.map((file) => new Promise((resolve) => {

--- a/tests/generate-svg.test.js
+++ b/tests/generate-svg.test.js
@@ -136,3 +136,34 @@ it(`Use prefix as function`, async () => {
 
     expect(svg).toBe(output);
 });
+
+it(`Sets id attribute when given in options`, async () => {
+    expect.assertions(2)
+
+    const svg = await generateSVG([
+        path.join(__dirname, 'input/svg/single.svg')
+      ], {
+        sprite: {
+            attributes: {
+                id: 'testID'
+            }
+        }
+    });
+
+    expect(svg).toMatch(/<svg(.*)(id="testID")(.*?)>/)
+    expect(svg).not.toMatch(/<svg(.*)(id="NOMATCH")(.*?)/)
+});
+
+it(`Skips id attribute when not a string`, async () => {
+    const svg = await generateSVG([
+      path.join(__dirname, 'input/svg/single.svg')
+    ], {
+        sprite: {
+            attributes: {
+                id: 1
+            }
+        }
+    })
+
+    expect(svg).not.toMatch(/<svg(.*)(id="1")(.*?)>/)
+})


### PR DESCRIPTION
Hello, I have the wish to set an id attribute on the root element of the generated sprite. I'm currently in-lining the generated sprite and this allows for easy targeting from CSS.