### PR TITLE
Fix watching for windows paths

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -317,7 +317,8 @@ module.exports = class SVGSpritemapPlugin {
         }, []);
 
         this.directories = inputOptions.patterns.reduce((accumulator, value) => {
-            const directories = glob.sync(`${value.substring(0, value.lastIndexOf('/'))}/`, inputOptions.options).map((directory) => {
+            value = value.substring(0, value.lastIndexOf(path.sep))
+            const directories = glob.sync(value, inputOptions.options).map((directory) => {
                 return path.resolve(directory);
             });
 


### PR DESCRIPTION
Hey!

I'm using the plugin with already `path.resolve`d paths on windows hosts. They end up being in this format: `C:\users\user\projects\project\icons`. When these paths went through your parser, they ended up being just `C:\`. The substring result was empty, because there is no `/` and path.resolve from empty string is `C:\`. This causes Node to crash as it tries to watch everything within user's filesystem... :)

This PR fixed it for my use case and I've tested it on Linux as well to check if it didn't break anything.

Also, the trailing slash was redundand, as `path.resolve` strips it anyway.

Let me know what you think :)