### PR TITLE
Clean up .map files if they exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -284,17 +284,16 @@ module.exports = class SVGSpritemapPlugin {
             }
 
             compilation.chunks.forEach((chunk) => {
-                const sourceMapStr = `${chunk.files[0]}.map`;
                 
                 if ( chunk.name !== outputOptions.chunk.name ) {
                     return;
                 }
 
-                delete assets[chunk.files[0]];
-
-                if (assets[sourceMapStr]) {
-                    delete compilation.assets[sourceMapStr];
+                if ( typeof chunk.files[1] !== 'undefined' ) {
+                    delete assets[chunk.files[1]];
                 }
+
+                delete assets[chunk.files[0]];
             });
 
             return callback();

--- a/lib/index.js
+++ b/lib/index.js
@@ -289,7 +289,7 @@ module.exports = class SVGSpritemapPlugin {
                     return;
                 }
 
-                if ( typeof chunk.files[1] !== 'undefined' ) {
+                if ( typeof chunk.files[1] !== 'undefined' && chunk.files[1].indexOf('.map') !== -1 ) {
                     delete assets[chunk.files[1]];
                 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -276,17 +276,25 @@ module.exports = class SVGSpritemapPlugin {
         // Clean up the spritemap chunk
         compiler.hooks.emit.tapAsync(plugin, (compilation, callback) => {
             const { output: outputOptions } = this.options;
+            const assets = compilation.assets;
+            
 
             if ( outputOptions.chunk.keep ) {
                 return callback();
             }
 
             compilation.chunks.forEach((chunk) => {
+                const sourceMapStr = `${chunk.files[0]}.map`;
+                
                 if ( chunk.name !== outputOptions.chunk.name ) {
                     return;
                 }
 
-                delete compilation.assets[chunk.files[0]];
+                delete assets[chunk.files[0]];
+
+                if (assets[sourceMapStr]) {
+                    delete compilation.assets[sourceMapStr];
+                }
             });
 
             return callback();

--- a/lib/index.js
+++ b/lib/index.js
@@ -276,24 +276,22 @@ module.exports = class SVGSpritemapPlugin {
         // Clean up the spritemap chunk
         compiler.hooks.emit.tapAsync(plugin, (compilation, callback) => {
             const { output: outputOptions } = this.options;
-            const assets = compilation.assets;
             
-
             if ( outputOptions.chunk.keep ) {
                 return callback();
             }
 
             compilation.chunks.forEach((chunk) => {
-                
+
                 if ( chunk.name !== outputOptions.chunk.name ) {
                     return;
                 }
 
-                if ( typeof chunk.files[1] !== 'undefined' && chunk.files[1].indexOf('.map') !== -1 ) {
-                    delete assets[chunk.files[1]];
+                if ( typeof chunk.files[1] !== 'undefined' && chunk.files[1] === `${chunk.files[0]}.map` ) {
+                    delete compilation.assets[chunk.files[1]];
                 }
 
-                delete assets[chunk.files[0]];
+                delete compilation.assets[chunk.files[0]];
             });
 
             return callback();

--- a/tests/generate-svg.test.js
+++ b/tests/generate-svg.test.js
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
 import generateSVG from '../lib/generate-svg';
+import SVGSpritemapPlugin from '../lib/';
+import webpack from 'webpack';
+
+
 
 it('Returns undefined when no files are specified', async () => {
     const svg = await generateSVG([]);
@@ -135,4 +139,49 @@ it(`Use prefix as function`, async () => {
     });
 
     expect(svg).toBe(output);
+});
+
+it(`Deletes Javascipt file`, done => {
+    const chunkName = 'test';
+
+    webpack({
+        entry: './webpack/index.js',
+        plugins: [
+            new SVGSpritemapPlugin(path.join(__dirname, 'input/svg/single.svg'), {
+                output: {
+                    chunk: {
+                        name: chunkName
+                    }
+                }
+            })
+        ]
+    }, (err, stats) => {
+        const outputFiles = stats.toJson().assets.map(x => x.name);
+        expect(outputFiles.indexOf(`${chunkName}.js`) === -1).toBeTruthy();
+        done();
+    });
+});
+
+
+it(`Deletes sourcemap file`, done => {
+    const chunkName = 'test';
+
+    webpack({
+        entry: './webpack/index.js',
+        mode: 'development',
+        devtool: 'hidden-source-map',
+        plugins: [
+            new SVGSpritemapPlugin(path.join(__dirname, 'input/svg/single.svg'), {
+                output: {
+                    chunk: {
+                        name: chunkName
+                    }
+                }
+            })
+        ]
+    }, (err, stats) => {
+        const outputFiles = stats.toJson().assets.map(x => x.name);
+        expect(outputFiles.indexOf(`${chunkName}.js.map`) === -1).toBeTruthy();
+        done();
+    });
 });


### PR DESCRIPTION
In dev mode, I kept getting a .map file, and deleting the file again & again got to be a tab cumbersome. Let me know if you want this handled differently; I would love not to use a fork for something this simple. Thanks for this awesome plugin! 