### PR TITLE
Do not allow boolean value as postfix for fragment option

### DIFF
--- a/lib/style-formatters/css.js
+++ b/lib/style-formatters/css.js
@@ -38,7 +38,7 @@ module.exports = (symbols = [], options = {}) => {
                 case 'data':
                     return svgToMiniDataURI(XMLSerializer.serializeToString(svg));
                 case 'fragment':
-                    return `${options.format.publicPath}#${options.prefix}${selector}${options.postfix.view}`;
+                    return `${options.format.publicPath}#${options.prefix}${selector}${typeof options.postfix.view === 'boolean' ? '' : options.postfix.view}`;
             }
         })(svg);
 

--- a/lib/style-formatters/less.js
+++ b/lib/style-formatters/less.js
@@ -41,7 +41,7 @@ module.exports = (symbols = [], options = {}) => {
                 case 'data':
                     return svgToMiniDataURI(XMLSerializer.serializeToString(svg));
                 case 'fragment':
-                    return `${options.format.publicPath}#${options.prefix}${selector}${options.postfix.view}`;
+                    return `${options.format.publicPath}#${options.prefix}${selector}${typeof options.postfix.view === 'boolean' ? '' : options.postfix.view}`;
             }
         })(svg);
 

--- a/lib/style-formatters/scss.js
+++ b/lib/style-formatters/scss.js
@@ -80,7 +80,7 @@ module.exports = (symbols = [], options = {}) => {
                         return `${attribute}="___${name}___"`;
                     }));
                 case 'fragment':
-                    return `${options.format.publicPath}#${options.prefix}${selector}${options.postfix.view}`;
+                    return `${options.format.publicPath}#${options.prefix}${selector}${typeof options.postfix.view === 'boolean' ? '' : options.postfix.view}`;
             }
         })(sprite);
 


### PR DESCRIPTION
> Whether to include a <view> element for each sprite within the generated spritemap to allow referencing via fragment identifiers. Passing a string will use the value as a postfix for the id attribute.

At the moment passing of a boolean value does also add a postfix `true` or `false`. This results in identifiers like this:
`.arrow-left { background-image: url("/build/sprite.svg#arrow-leftfalse"); }`