### PR TITLE
Options to output width/height instead of background-size in SCSS mixin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /*.scss
 /*.sass
 /*.less
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,3 @@
 /*.scss
 /*.sass
 /*.less
-.DS_Store

--- a/lib/templates/styles.scss
+++ b/lib/templates/styles.scss
@@ -44,7 +44,7 @@ $/* VAR_VARIABLES */: (
     @return $encoded;
 }
 
-@mixin /* VAR_MIXIN */($name, $user-variables: (), $include-size: false, $use-background: true) {
+@mixin /* VAR_MIXIN */($name, $user-variables: (), $include-size: false, $use-background-size: true) {
     $sprite: map-get($/* VAR_SPRITES */, $name);
 
     // Inject variables
@@ -65,7 +65,7 @@ $/* VAR_VARIABLES */: (
 
     @if $include-size {
 		$size: map-get($/* VAR_SIZES */, $name);
-		@if $use-background {
+		@if $use-background-size {
 			background-size: map-get($size, width) map-get($size, height);
 		} @else {
 			width: map-get($size, width);

--- a/lib/templates/styles.scss
+++ b/lib/templates/styles.scss
@@ -64,12 +64,12 @@ $/* VAR_VARIABLES */: (
     background: url($sprite) center no-repeat;
 
     @if $include-size {
-		$size: map-get($/* VAR_SIZES */, $name);
-		@if $use-background-size {
-			background-size: map-get($size, width) map-get($size, height);
-		} @else {
-			width: map-get($size, width);
-			height: map-get($size, height);
-		}
+        $size: map-get($/* VAR_SIZES */, $name);
+        @if $use-background-size {
+            background-size: map-get($size, width) map-get($size, height);
+        } @else {
+            width: map-get($size, width);
+            height: map-get($size, height);
+        }
     }
 }

--- a/lib/templates/styles.scss
+++ b/lib/templates/styles.scss
@@ -44,7 +44,7 @@ $/* VAR_VARIABLES */: (
     @return $encoded;
 }
 
-@mixin /* VAR_MIXIN */($name, $user-variables: (), $include-size: false) {
+@mixin /* VAR_MIXIN */($name, $user-variables: (), $include-size: false, $use-background: true) {
     $sprite: map-get($/* VAR_SPRITES */, $name);
 
     // Inject variables
@@ -64,7 +64,12 @@ $/* VAR_VARIABLES */: (
     background: url($sprite) center no-repeat;
 
     @if $include-size {
-        $size: map-get($/* VAR_SIZES */, $name);
-        background-size: map-get($size, width) map-get($size, height);
+		$size: map-get($/* VAR_SIZES */, $name);
+		@if $use-background {
+			background-size: map-get($size, width) map-get($size, height);
+		} @else {
+			width: map-get($size, width);
+			height: map-get($size, height);
+		}
     }
 }

--- a/lib/templates/styles.scss
+++ b/lib/templates/styles.scss
@@ -44,7 +44,7 @@ $/* VAR_VARIABLES */: (
     @return $encoded;
 }
 
-@mixin /* VAR_MIXIN */($name, $user-variables: (), $include-size: false, $use-background-size: true) {
+@mixin /* VAR_MIXIN */($name, $user-variables: (), $include-size: false) {
     $sprite: map-get($/* VAR_SPRITES */, $name);
 
     // Inject variables
@@ -65,9 +65,9 @@ $/* VAR_VARIABLES */: (
 
     @if $include-size {
         $size: map-get($/* VAR_SIZES */, $name);
-        @if $use-background-size {
+        @if $include-size == true {
             background-size: map-get($size, width) map-get($size, height);
-        } @else {
+        } @else if $include-size == 'box' {
             width: map-get($size, width);
             height: map-get($size, height);
         }

--- a/tests/output/styles/sprites-attributes.scss
+++ b/tests/output/styles/sprites-attributes.scss
@@ -68,6 +68,11 @@ $variables: (
 
     @if $include-size {
         $size: map-get($sizes, $name);
-        background-size: map-get($size, width) map-get($size, height);
+        @if $include-size == true {
+            background-size: map-get($size, width) map-get($size, height);
+        } @else if $include-size == 'box' {
+            width: map-get($size, width);
+            height: map-get($size, height);
+        }
     }
 }

--- a/tests/output/styles/sprites-fragments.scss
+++ b/tests/output/styles/sprites-fragments.scss
@@ -68,6 +68,11 @@ $variables: (
 
     @if $include-size {
         $size: map-get($sizes, $name);
-        background-size: map-get($size, width) map-get($size, height);
+        @if $include-size == true {
+            background-size: map-get($size, width) map-get($size, height);
+        } @else if $include-size == 'box' {
+            width: map-get($size, width);
+            height: map-get($size, height);
+        }
     }
 }

--- a/tests/output/styles/sprites.scss
+++ b/tests/output/styles/sprites.scss
@@ -68,6 +68,11 @@ $variables: (
 
     @if $include-size {
         $size: map-get($sizes, $name);
-        background-size: map-get($size, width) map-get($size, height);
+        @if $include-size == true {
+            background-size: map-get($size, width) map-get($size, height);
+        } @else if $include-size == 'box' {
+            width: map-get($size, width);
+            height: map-get($size, height);
+        }
     }
 }


### PR DESCRIPTION
In multiple scenario you need to enter the width/height of the svg instead of a background-size. I added an option to the mixin to output the width/height OR the background-size depending of the flag `$use-background-size`.

```scss
.hello {
    @include sprite('test', (), true, false);
    content: '';
}
```

Will output

```scss
.hello {
    content: '';
    background-image: (data:image...);
    width: 15px;
    height: 15px;
}
```