### PR TITLE
Bulletproof the the warnings inclusion

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -200,7 +200,7 @@ module.exports = class SVGSpritemapPlugin {
                         }
 
                         // Include warnings received from the style formatters
-                        if ( this.styles.warnings.length ) {
+                        if ( this.styles && this.styles.warnings && this.styles.warnings.length ) {
                             compilation.warnings = [...compilation.warnings, ...this.styles.warnings];
                         }
 


### PR DESCRIPTION
If there are no warnings, the `length` will be unreadable and throw a fatal error.