### PR TITLE
Raise contenthash length from 16 to 32 characters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -463,7 +463,7 @@ module.exports = class SVGSpritemapPlugin {
 
         const source = typeof asset.source === 'string' ? asset.source : asset.source._value;
         const hash = compilation.hash;
-        const contenthash = asset && loaderUtils.getHashDigest(source, 'sha1', 'hex', 16);
+        const contenthash = asset && loaderUtils.getHashDigest(source, 'sha1', 'hex', 32);
 
         const newFilename = [{
             pattern: /\[hash]/,


### PR DESCRIPTION
This would solve this issue: https://github.com/cascornelissen/svg-spritemap-webpack-plugin/issues/149 since https://github.com/shellscape/webpack-manifest-plugin (v3.0.0) by default does only replace hashes which are 32 chars long.

I am not sure what this would mean for BC. If you do not agree with this change, please just close the PR.