### PR TITLE
Add filepath as second param to `options.sprite.idify`

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -134,6 +134,10 @@ Whether to also prefix any selectors that are generated in the styles file, if e
 #### `sprite.idify` – `require('html4-id')`
 Function that will be used to transform the filename of each sprite into a valid HTML `id`. The default function uses [`html4-id`](https://www.npmjs.com/package/html4-id) to generate a valid HTML4 id which has quite a [few restrictions](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id) and since HTML5 allows pretty much anything as long as there's no whitespace it's possible to change this function. Passing `false` will result in the filename getting used as-is.
 
+Function parameters:
+- `filename` - The name of the file without the extension (e.g. `calendar`)
+- `filepath` - The full path of the file (e.g. `/path/to/calendar.svg`)
+
 ```es6
 // Generate HTML5 id's
 (filename) => filename.replace(/[\s]+/g, '-');

--- a/lib/generate-svg.js
+++ b/lib/generate-svg.js
@@ -111,7 +111,7 @@ module.exports = (sources = [], options = {}, compilation) => {
 
         Promise.all(sources.map((source) => new Promise((resolve) => {
             const prefix = generateSpritePrefix(options.sprite.prefix, source.path);
-            const id = `${prefix}${options.sprite.idify(path.basename(source.path, path.extname(source.path)))}`;
+            const id = `${prefix}${options.sprite.idify(path.basename(source.path, path.extname(source.path)), source.path)}`;
 
             if ( options.output.svgo === false ) {
                 return resolve({

--- a/tests/generate-svg.test.js
+++ b/tests/generate-svg.test.js
@@ -162,6 +162,23 @@ it('Use prefix as function', async () => {
     expect(svg).toEqual(output);
 });
 
+it('Generates custom IDs correctly when \'options.sprite.idify\' is defined', async () => {
+    const output = fs.readFileSync(path.resolve(__dirname, 'output/svg/single-with-custom-ids.svg'), 'utf-8').trim();
+    const svg = await generateSVG([{
+        path: path.resolve(__dirname, 'input/svg/single.svg'),
+        content: fs.readFileSync(path.resolve(__dirname, 'input/svg/single.svg'), 'utf-8')
+    }], {
+        sprite: {
+            idify: (filename, filepath) => {
+                const parentDirectory = path.basename(path.dirname(filepath));
+                return `custom__${parentDirectory}__${filename}`;
+            }
+        }
+    });
+
+    expect(svg).toEqual(output);
+});
+
 it('Should not transfer non-valid attributes to the root SVG', async () => {
     const output = fs.readFileSync(path.resolve(__dirname, 'output/svg/attributes-no-transfer-invalid-root.svg'), 'utf-8').trim();
     const svg = await generateSVG([{

--- a/tests/output/svg/single-with-custom-ids.svg
+++ b/tests/output/svg/single-with-custom-ids.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"><symbol fill="red" id="custom__svg__single" viewBox="0 0 24 24"><title>custom__svg__single</title><path d="M21 7L9 19l-5.5-5.5 1.41-1.41L9 16.17 19.59 5.59 21 7z"/></symbol></svg>


### PR DESCRIPTION
Hello there! 👋 

I recently started to use this great plugin, and I run into an issue:
In my project the icons are organised in sub folders (e.g. `actions`, `brands` etc), and I would like to include the sub folder name in the generated ID (e.g. `{subfolder}-{iconname}`).

I noticed there is a way to provide a custom ID generator function in `options.sprite.idify`, but that only receives the file name of the icon as a parameter.

So I thought I could add the filepath as the second parameter for `idify`, which would help me to solve my issue without introducing a breaking change.

Please let me know if I missed anything!