### PR TITLE
[feature] Validate empty prefix for `sprite.prefix`

### DIFF
--- a/lib/options-validator.js
+++ b/lib/options-validator.js
@@ -33,7 +33,7 @@ module.exports = (pattern, options = {}) => {
             }),
             sprite: Joi.object({
                 prefix: Joi.alternatives([
-                    Joi.string(),
+                    Joi.string().allow(''),
                     Joi.valid(false),
                     Joi.func()
                 ]),

--- a/tests/plugin-options.test.js
+++ b/tests/plugin-options.test.js
@@ -1,5 +1,17 @@
 import formatOptions from '../lib/options-formatter';
 
+describe('Input validation', () => {
+    it('Accepts an empty prefix', () => {
+        const output = formatOptions({
+            sprite: {
+                prefix: ""
+            }
+        });
+
+        expect(output.sprite.prefix).toEqual("");
+    })
+});
+
 describe('Input rewriting', () => {
     it('Transforms a string pattern to an array with the single pattern', () => {
         const pattern = 'a';


### PR DESCRIPTION
Fixes #168 