### PR TITLE
Update xmldom to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "svgo": "^2.4.0",
         "webpack-merge": "^5.7.3",
         "webpack-sources": "^2.2.0",
-        "xmldom": "^0.6.0"
+        "@xmldom/xmldom": "^0.7.0"
     },
     "devDependencies": {
         "@babel/preset-env": "^7.13.15",


### PR DESCRIPTION
The package is now scoped as @xmldom. See xmldom/xmldom#278
this fixes CVE-2021-32796 https://nvd.nist.gov/vuln/detail/CVE-2021-32796