### PR TITLE
Adds sprite width/height output options + `rem` units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /node_modules
 /coverage
 /dist
+.DS_Store
 
 # Generated files
 /svg4everybody-helper.js

--- a/docs/options.md
+++ b/docs/options.md
@@ -53,8 +53,10 @@ new SVGSpritemapPlugin(string | string[], {
     },
     styles?: boolean | string | {
         filename?: string,
-        format?: 'data' | 'fragment',
+        format?: 'data' | 'fragment' | 'dimensions',
         keepAttributes?: boolean,
+        includeDimensions?: boolean,
+        units?: 'rem' | 'px',
         variables?: {
             sprites?: string,
             sizes?: string,
@@ -216,10 +218,6 @@ The value for the `styles` option should end in a supported style extension and 
       background-image: url(@sprite-phone);
   }
   ```
-
-#### `styles.keepAttributes` – `false`
-Whether to include the original SVG attributes in the generated styles.
-
 #### `styles.format` – `'data'`
 Format of the styles that will be generated, the following values are valid:
 
@@ -227,6 +225,35 @@ Format of the styles that will be generated, the following values are valid:
   Generates [data URIs](https://www.npmjs.com/package/mini-svg-data-uri) as background `url()`s.
 - `'fragment'`  
   Generates URLs with [fragment identifiers](https://css-tricks.com/svg-fragment-identifiers-work/) as background `url()`s. This requires the `sprite.generate.view` option to be enabled and uses the webpack option [`output.publicPath`](https://webpack.js.org/configuration/output/#output-publicpath) to build a URL to the file. This type of setup requires some additional configuration, [see example](../examples/fragments) for more information.
+- `'dimensions'` (only with a CSS output)
+  Generates only dimension information about the sprites in your sprite map. For example:
+
+  ```CSS
+  .sprite-foo { width: 1.5rem; height: 1.5rem; }
+  ```
+
+#### `styles.keepAttributes` – `false`
+Whether to include the original SVG attributes in the generated styles.
+
+#### `styles.includeDimensions` – `false` (only with a CSS output)
+Whether to include the individual SVG dimensions in the generated styles.
+
+For example, with the default `false`:
+
+```CSS
+.sprite-foo { background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 7 9 19l-5.5-5.5 1.41-1.41L9 16.17 19.59 5.59 21 7Z'/%3e%3c/svg%3e"); }
+```
+
+And, if set to `true`:
+
+```CSS
+.sprite-foo { background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 7 9 19l-5.5-5.5 1.41-1.41L9 16.17 19.59 5.59 21 7Z'/%3e%3c/svg%3e"); width: 1.5rem; height: 1.5rem; }
+```
+
+Useful if you know you're going to be displaying the sprite at their original sizes.
+
+#### `styles.units` – `'rem'`
+CSS units for outputted dimensions, defaults to `rem` with `px` also being available.
 
 #### `styles.variables.sprites` – `'sprites'`
 Name for the SCSS variable that is used for the Sass map containing sprites.

--- a/lib/generate-styles.js
+++ b/lib/generate-styles.js
@@ -46,6 +46,8 @@ module.exports = (spritemap, options = {}, sources = []) => {
         prefixStylesSelectors: options.prefixStylesSelectors,
         postfix: options.postfix,
         keepAttributes: options.keepAttributes,
+        includeDimensions: options.includeDimensions,
+        units: options.units,
         format: options.format,
         variables: options.variables,
         callback: options.callback

--- a/lib/helpers/px-to-rem.js
+++ b/lib/helpers/px-to-rem.js
@@ -1,0 +1,1 @@
+module.exports = (value) => Math.round((value/16)*10000)/10000;

--- a/lib/index.js
+++ b/lib/index.js
@@ -324,8 +324,13 @@ module.exports = class SVGSpritemapPlugin {
         }
 
         // Emit a warning that includeDimensions only applies to CSS outputs
-        if ( extension !== 'css' && stylesOptions.includeDimensions === true) {
+        if ( extension !== 'css' && stylesOptions.includeDimensions === true ) {
             this.warnings.push(new OptionsMismatchWarning(`Using 'includeDimensions' only applies to CSS output - ignoring setting`));
+        }
+
+        // Emit a warning that includeDimensions only applies if you aren't using dimensions format
+        if ( stylesOptions.format === 'dimensions' && extension === 'css' && stylesOptions.includeDimensions === true ) {
+            this.warnings.push(new OptionsMismatchWarning(`Using 'includeDimensions' only applies to a 'format' setting of 'data' or 'fragment' - ignoring setting`));
         }
 
         // Include warnings received from the style formatters

--- a/lib/index.js
+++ b/lib/index.js
@@ -269,9 +269,18 @@ module.exports = class SVGSpritemapPlugin {
 
         const extension = path.extname(stylesOptions.filename).substring(1).toLowerCase();
 
+        // Emit a warning when using `dimensions` and a file format that isn't CSS
+        // and set the format to `data` to ensure some output
+        if (stylesOptions.format === 'dimensions' && extension !== 'css') {
+            this.warnings.push(new OptionsMismatchWarning(`Using styles.format with value 'dimensions' is only compatible with CSS file formats - defaulting to styles.format 'data'`));
+            stylesOptions.format = 'data';
+        }
+
         this.styles = generateStyles(this.spritemap, {
             extension: extension,
             keepAttributes: stylesOptions.keepAttributes,
+            includeDimensions: stylesOptions.includeDimensions,
+            units: stylesOptions.units,
             prefix: spriteOptions.prefix,
             prefixStylesSelectors: spriteOptions.prefixStylesSelectors,
             postfix: {
@@ -312,6 +321,11 @@ module.exports = class SVGSpritemapPlugin {
         // Emit a warning when using [hash] in filename while using 'fragment' for styles.format
         if ( stylesOptions.format === 'fragment' && outputOptions.filename.includes('[hash]') ) {
             this.warnings.push(new OptionsMismatchWarning(`Using styles.format with value 'fragment' in combination with [hash] in output.filename will results in incorrect fragment URLs`));
+        }
+
+        // Emit a warning that includeDimensions only applies to CSS outputs
+        if ( extension !== 'css' && stylesOptions.includeDimensions === true) {
+            this.warnings.push(new OptionsMismatchWarning(`Using 'includeDimensions' only applies to CSS output - ignoring setting`));
         }
 
         // Include warnings received from the style formatters

--- a/lib/options-formatter.js
+++ b/lib/options-formatter.js
@@ -109,6 +109,7 @@ module.exports = (pattern, options) => {
         output.styles = merge({
             filename: '~sprites.css',
             format: 'data',
+            units: 'rem',
             variables: {
                 sprites: 'sprites',
                 sizes: 'sizes',

--- a/lib/options-validator.js
+++ b/lib/options-validator.js
@@ -66,8 +66,10 @@ module.exports = (pattern, options = {}) => {
                 Joi.string(),
                 Joi.object({
                     filename: Joi.string(),
-                    format: Joi.string().valid('data', 'fragment'),
+                    format: Joi.string().valid('data', 'fragment', 'dimensions'),
                     keepAttributes: Joi.boolean(),
+                    includeDimensions: Joi.boolean(),
+                    units: Joi.string().valid('rem', 'px'),
                     variables: Joi.object({
                         sprites: Joi.string(),
                         sizes: Joi.string(),

--- a/lib/style-formatters/css.js
+++ b/lib/style-formatters/css.js
@@ -1,6 +1,7 @@
 const xmldom = require('@xmldom/xmldom');
 const svgToMiniDataURI = require('mini-svg-data-uri');
 const generateSpritePrefix = require('../helpers/generate-sprite-prefix');
+const pxToRem = require('../helpers/px-to-rem');
 const { merge } = require('webpack-merge');
 
 module.exports = (symbols = [], options = {}, sources = []) => {
@@ -12,6 +13,8 @@ module.exports = (symbols = [], options = {}, sources = []) => {
             view: ''
         },
         keepAttributes: false,
+        includeDimensions: false,
+        units: 'rem',
         format: {
             type: 'data',
             publicPath: ''
@@ -46,19 +49,30 @@ module.exports = (symbols = [], options = {}, sources = []) => {
             svg.appendChild(childNode);
         });
 
+        // Extract width/height from viewbox
+        const size = symbol.getAttribute('viewBox').split(' ').slice(2);
+        const width = options.units === 'rem' ? `${pxToRem(size[0])}rem` : `${size[0]}px`;
+        const height = options.units === 'rem' ? `${pxToRem(size[1])}rem` : `${size[1]}px`;
+
         const prefix = generateSpritePrefix(options.prefix, sources[index].path);
         const selector = symbol.getAttribute('id').replace(prefix, '').replace(options.postfix.symbol, '');
-        const content = ((svg) => {
+        let content = ((svg) => {
             switch ( options.format.type ) {
                 case 'data':
-                    return svgToMiniDataURI(XMLSerializer.serializeToString(svg));
+                    return ` background-image: url("${svgToMiniDataURI(XMLSerializer.serializeToString(svg))}");`;
                 case 'fragment':
                     const postfix = typeof options.postfix.view === 'boolean' ? '' : options.postfix.view;
-                    return `${options.format.publicPath}#${prefix}${selector}${postfix}`;
+                    return ` background-image: url("${options.format.publicPath}#${prefix}${selector}${postfix}");`;
+                default:
+                    return '';
             }
         })(svg);
 
-        return `.${options.prefixStylesSelectors ? `${prefix}${selector}` : selector} { background-image: url("${content}"); }`;
+        if (options.includeDimensions || options.format.type === 'dimensions') {
+            content += ` width: ${width}; height: ${height};`;
+        }
+
+        return `.${options.prefixStylesSelectors ? `${prefix}${selector}` : selector} {${content} }`;
     });
 
     return {

--- a/lib/style-formatters/scss.js
+++ b/lib/style-formatters/scss.js
@@ -3,6 +3,7 @@ const path = require('path');
 const xmldom = require('@xmldom/xmldom');
 const svgToMiniDataURI = require('mini-svg-data-uri');
 const generateSpritePrefix = require('../helpers/generate-sprite-prefix');
+const pxToRem = require('../helpers/px-to-rem');
 const { merge } = require('webpack-merge');
 
 // Helpers
@@ -29,6 +30,7 @@ module.exports = (symbols = [], options = {}, sources = []) => {
             view: ''
         },
         keepAttributes: false,
+        units: 'rem',
         format: {
             type: 'data',
             publicPath: ''
@@ -75,8 +77,8 @@ module.exports = (symbols = [], options = {}, sources = []) => {
 
         // Extract width/height from viewbox
         const size = symbol.getAttribute('viewBox').split(' ').slice(2);
-        const width = size[0];
-        const height = size[1];
+        const width = options.units === 'rem' ? `${pxToRem(size[0])}rem` : `${size[0]}px`;
+        const height = options.units === 'rem' ? `${pxToRem(size[1])}rem` : `${size[1]}px`;
 
         // Validate the current sprite
         const warnings = findDefaultValueMismatches(sprite).map((mismatch) => {
@@ -107,7 +109,7 @@ module.exports = (symbols = [], options = {}, sources = []) => {
             ],
             sizes: [
                 ...accumulator.sizes,
-                `'${options.prefixStylesSelectors ? `${prefix}${selector}` : selector}': (\n${indent(2)}'width': ${width}px,\n${indent(2)}'height': ${height}px\n${indent()})`
+                `'${options.prefixStylesSelectors ? `${prefix}${selector}` : selector}': (\n${indent(2)}'width': ${width},\n${indent(2)}'height': ${height}\n${indent()})`
             ],
             variables: [
                 ...accumulator.variables,

--- a/tests/generate-styles.test.js
+++ b/tests/generate-styles.test.js
@@ -78,6 +78,40 @@ describe('CSS', () => {
             path: input
         }]).content.trim()).toEqual(output);
     });
+
+    it('Generates styles with dimensions', async () => {
+        const input = path.resolve(__dirname, 'input/svg/single.svg');
+        const output = fs.readFileSync(path.resolve(__dirname, 'output/styles/sprites-dimensions.css'), 'utf-8').trim();
+        const spritemap = await generateSVG([{
+            path: input,
+            content: fs.readFileSync(path.resolve(__dirname, 'input/svg/single.svg'), 'utf-8')
+        }], DEFAULT_OPTIONS);
+
+        expect(generateStyles(spritemap, {
+            extension: 'css',
+            includeDimensions: true,
+        }, [{
+            path: input
+        }]).content.trim()).toEqual(output);
+    });
+
+    it('Generates dimensions only', async () => {
+        const input = path.resolve(__dirname, 'input/svg/single.svg');
+        const output = fs.readFileSync(path.resolve(__dirname, 'output/styles/dimensions.css'), 'utf-8').trim();
+        const spritemap = await generateSVG([{
+            path: input,
+            content: fs.readFileSync(path.resolve(__dirname, 'input/svg/single.svg'), 'utf-8')
+        }], DEFAULT_OPTIONS);
+
+        expect(generateStyles(spritemap, {
+            extension: 'css',
+            format: {
+                type: 'dimensions'
+            }
+        }, [{
+            path: input
+        }]).content.trim()).toEqual(output);
+    });
 });
 
 describe('SCSS', () => {
@@ -98,7 +132,7 @@ describe('SCSS', () => {
 
     it('Generates styles with passed attributes', async () => {
         const input = path.resolve(__dirname, 'input/svg/single.svg');
-        const output = fs.readFileSync(path.resolve(__dirname, 'output/styles/sprites-attributes.scss'), 'utf-8').trim();
+        const output = fs.readFileSync(path.resolve(__dirname, 'output/styles/sprites-attributes-px.scss'), 'utf-8').trim();
         const spritemap = await generateSVG([{
             path: input,
             content: fs.readFileSync(path.resolve(__dirname, 'input/svg/single.svg'), 'utf-8')
@@ -106,7 +140,8 @@ describe('SCSS', () => {
 
         expect(generateStyles(spritemap, {
             extension: 'scss',
-            keepAttributes: true
+            keepAttributes: true,
+            units: 'px',
         }, [{
             path: input
         }]).content.trim()).toEqual(output);

--- a/tests/output/styles/dimensions.css
+++ b/tests/output/styles/dimensions.css
@@ -1,0 +1,1 @@
+.sprite-single { width: 1.5rem; height: 1.5rem; }

--- a/tests/output/styles/sprites-attributes-px.scss
+++ b/tests/output/styles/sprites-attributes-px.scss
@@ -1,11 +1,11 @@
 $sprites: (
-    'sprite-single': "#sprite-single"
+    'sprite-single': "data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='red' viewBox='0 0 24 24'%3e%3cpath d='M21 7 9 19l-5.5-5.5 1.41-1.41L9 16.17 19.59 5.59 21 7Z'/%3e%3c/svg%3e"
 );
 
 $sizes: (
     'sprite-single': (
-        'width': 1.5rem,
-        'height': 1.5rem
+        'width': 24px,
+        'height': 24px
     )
 );
 

--- a/tests/output/styles/sprites-attributes.scss
+++ b/tests/output/styles/sprites-attributes.scss
@@ -4,8 +4,8 @@ $sprites: (
 
 $sizes: (
     'sprite-single': (
-        'width': 24px,
-        'height': 24px
+        'width': 1.5rem,
+        'height': 1.5rem
     )
 );
 

--- a/tests/output/styles/sprites-dimensions.css
+++ b/tests/output/styles/sprites-dimensions.css
@@ -1,0 +1,1 @@
+.sprite-single { background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg'%3e%3cpath d='M21 7 9 19l-5.5-5.5 1.41-1.41L9 16.17 19.59 5.59 21 7Z'/%3e%3c/svg%3e"); width: 1.5rem; height: 1.5rem; }

--- a/tests/output/styles/sprites.scss
+++ b/tests/output/styles/sprites.scss
@@ -4,8 +4,8 @@ $sprites: (
 
 $sizes: (
     'sprite-single': (
-        'width': 24px,
-        'height': 24px
+        'width': 1.5rem,
+        'height': 1.5rem
     )
 );
 

--- a/tests/warnings.test.js
+++ b/tests/warnings.test.js
@@ -100,6 +100,15 @@ const warnings = [{
         }
     },
     message: 'Using \'includeDimensions\' only applies to CSS output - ignoring setting'
+}, {
+    options: {
+        styles: {
+            filename: 'test.css',
+            includeDimensions: true,
+            format: 'dimensions'
+        }
+    },
+    message: 'Using \'includeDimensions\' only applies to a \'format\' setting of \'data\' or \'fragment\' - ignoring setting'
 }];
 
 warnings.forEach((warning) => {

--- a/tests/warnings.test.js
+++ b/tests/warnings.test.js
@@ -83,6 +83,23 @@ const warnings = [{
         }
     },
     message: 'Using styles.format with value \'fragment\' in combination with [hash] in output.filename will results in incorrect fragment URLs'
+}, {
+    options: {
+        styles: {
+            filename: 'test.scss',
+            format: 'dimensions'
+        }
+    },
+    message: 'Using styles.format with value \'dimensions\' is only compatible with CSS file formats - defaulting to styles.format \'data\''
+}, {
+    options: {
+        styles: {
+            filename: 'test.scss',
+            includeDimensions: true,
+            format: 'data'
+        }
+    },
+    message: 'Using \'includeDimensions\' only applies to CSS output - ignoring setting'
 }];
 
 warnings.forEach((warning) => {


### PR DESCRIPTION
* also adds option to include dimensions with `data`/`fragment`
* adds CSS unit selection between `rem` and `px` with `rem` default
* adds tests
* adds warnings for mismatches
* adds info about new features to `options.md`

---

A common use case for us at [AREA 17](http://www.area17.com/) is needing to insert icons into pages at the original authored size of the icon - because we often manually hint icons and especially logos to sit perfectly on the pixel grid, to render at their best, per size. So, lets say we have an "arrow" icon we want to display at 24px and at 32px. We might have separate icons rather than scaling one up and down - so we can have different weights, different hinting, better on pixel grid spacing etc.

Its useful for us to be able to:

```HTML
<svg aria-hidden="true" class="sprite-arrow--24">
  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sprite-arrow--24"></use>
</svg>
```

And it display a 24x24 SVG in the page without having to add additional classes manually such as:

```HTML
<svg aria-hidden="true" class="w-24 h-24">
  <use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#sprite-arrow--24"></use>
</svg>
```

So, this PR adds a `styles.format` option of `dimensions`, which, if you have selected a CSS file as your output, will output something like:

```CSS
.sprite-arrow { width: 0.6875rem; height: 1.25rem; }
.sprite-calendar { width: 1.25rem; height: 1.3125rem; }
```

If you want to keep using the background image based setup, there is an option `includeDimensions: true,`, which would output:

```CSS
.sprite-arrow { background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg'%3e%3cpath fill='none' stroke='white' stroke-width='2' stroke-linecap='round' stroke-linejoin='round' stroke-miterlimit='10' d='m.7.7 9.4 9.3-9.4 9.3'/%3e%3c/svg%3e"); width: 0.6875rem; height: 1.25rem; }
.sprite-calendar { background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg'%3e%3cg%3e%3cg%3e%3cpath fill='white' d='M17 21H3c-1.654 0-3-1.346-3-3V5c0-1.654 1.346-3 3-3h14c1.654 0 3 1.346 3 3v13c0 1.654-1.346 3-3 3zM3 4c-.551 0-1 .448-1 1v13c0 .552.449 1 1 1h14c.551 0 1-.448 1-1V5c0-.552-.449-1-1-1H3z'/%3e%3c/g%3e%3cg%3e%3cpath fill='white' d='M4 0h2v6H4z'/%3e%3c/g%3e%3cg%3e%3cpath fill='white' d='M14 0h2v6h-2z'/%3e%3c/g%3e%3c/g%3e%3cpath fill='white' d='M0 2h20v7H0z'/%3e%3c/svg%3e"); width: 1.25rem; height: 1.3125rem; }
```

or, using `fragment`:

```CSS
.sprite-arrow { background-image: url("/sprite.svg#sprite-arrow"); width: 0.6875rem; height: 1.25rem; }
.sprite-calendar { background-image: url("/sprite.svg#sprite-calendar"); width: 1.25rem; height: 1.3125rem; }
```

---

I've also added a `unit` selection option and changed the default output units to `rem`, with `px` being an option, for both CSS and SCSS formats so that any sprite usages can scale with user font scaling preferences.
