### PR TITLE
New feature: Keep dimensions

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -162,7 +162,7 @@ Whether to include a `<use>` element for each sprite within the generated sprite
 Whether to include a `<view>` element for each sprite within the generated spritemap to allow referencing via [fragment identifiers](https://css-tricks.com/svg-fragment-identifiers-work/). Passing a string will use the value as a postfix for the `id` attribute.
 
 #### `sprite.generate.dimensions` - `false`
-Whether to keep each SVG `height` and `width` attributes and add them to the generated symbol. Requires `output.svgo` to be `false` or selectively disabled [SVGO `removeDimensions` plugin](https://svgo.dev/docs/plugins/removeDimensions/).
+Whether to keep each SVG `height` and `width` attributes and add them to the generated symbol.
 
 ### Styles
 The `styles` object contains the configuration for the generated styles, it's disabled (`false`) by default. A string can be used as the value which will then be used for the `styles.filename` option.

--- a/docs/options.md
+++ b/docs/options.md
@@ -162,7 +162,7 @@ Whether to include a `<use>` element for each sprite within the generated sprite
 Whether to include a `<view>` element for each sprite within the generated spritemap to allow referencing via [fragment identifiers](https://css-tricks.com/svg-fragment-identifiers-work/). Passing a string will use the value as a postfix for the `id` attribute.
 
 #### `sprite.generate.keepDimensions` - `false`
-Whether to keep each SVG `height` and `width` attributes and add them to the generated symbol. Requires `output.svgo` to be `false` or set to custom options and deactivate the [`removeDimensions` plugin](https://svgo.dev/docs/plugins/removeDimensions/).
+Whether to keep each SVG `height` and `width` attributes and add them to the generated symbol. Requires `output.svgo` to be `false` or selectively disabled [SVGO `removeDimensions` plugin](https://svgo.dev/docs/plugins/removeDimensions/).
 
 ### Styles
 The `styles` object contains the configuration for the generated styles, it's disabled (`false`) by default. A string can be used as the value which will then be used for the `styles.filename` option.

--- a/docs/options.md
+++ b/docs/options.md
@@ -161,7 +161,7 @@ Whether to include a `<use>` element for each sprite within the generated sprite
 #### `sprite.generate.view` - `false`
 Whether to include a `<view>` element for each sprite within the generated spritemap to allow referencing via [fragment identifiers](https://css-tricks.com/svg-fragment-identifiers-work/). Passing a string will use the value as a postfix for the `id` attribute.
 
-#### `sprite.generate.keepDimensions` - `false`
+#### `sprite.generate.dimensions` - `false`
 Whether to keep each SVG `height` and `width` attributes and add them to the generated symbol. Requires `output.svgo` to be `false` or selectively disabled [SVGO `removeDimensions` plugin](https://svgo.dev/docs/plugins/removeDimensions/).
 
 ### Styles

--- a/docs/options.md
+++ b/docs/options.md
@@ -161,6 +161,8 @@ Whether to include a `<use>` element for each sprite within the generated sprite
 #### `sprite.generate.view` - `false`
 Whether to include a `<view>` element for each sprite within the generated spritemap to allow referencing via [fragment identifiers](https://css-tricks.com/svg-fragment-identifiers-work/). Passing a string will use the value as a postfix for the `id` attribute.
 
+#### `sprite.generate.keepDimensions` - `false`
+Whether to keep each SVG `height` and `width` attributes and add them to the generated symbol. Requires `output.svgo` to be `false` or set to custom options and deactivate the [`removeDimensions` plugin](https://svgo.dev/docs/plugins/removeDimensions/).
 
 ### Styles
 The `styles` object contains the configuration for the generated styles, it's disabled (`false`) by default. A string can be used as the value which will then be used for the `styles.filename` option.

--- a/lib/generate-svg.js
+++ b/lib/generate-svg.js
@@ -40,7 +40,8 @@ module.exports = (sources = [], options = {}, warnings = []) => {
                 title: true,
                 symbol: true,
                 use: false,
-                view: false
+                view: false,
+                keepDimensions: false
             }
         },
         output: {
@@ -229,6 +230,12 @@ module.exports = (sources = [], options = {}, warnings = []) => {
 
             symbol.setAttribute('id', `${item.id}${formatPostfix(options.sprite.generate.symbol)}`);
             symbol.setAttribute('viewBox', viewbox.join(' '));
+
+            if ( options.sprite.generate.keepDimensions ) {
+                symbol.setAttribute('height', height.toString());
+                symbol.setAttribute('width', width.toString());
+            }
+
             if ( options.sprite.generate.title ) {
                 // Make sure we don't overwrite the existing title
                 const hasTitle = (documentElement) => {

--- a/lib/generate-svg.js
+++ b/lib/generate-svg.js
@@ -41,7 +41,7 @@ module.exports = (sources = [], options = {}, warnings = []) => {
                 symbol: true,
                 use: false,
                 view: false,
-                keepDimensions: false
+                dimensions: false
             }
         },
         output: {
@@ -231,7 +231,7 @@ module.exports = (sources = [], options = {}, warnings = []) => {
             symbol.setAttribute('id', `${item.id}${formatPostfix(options.sprite.generate.symbol)}`);
             symbol.setAttribute('viewBox', viewbox.join(' '));
 
-            if ( options.sprite.generate.keepDimensions ) {
+            if ( options.sprite.generate.dimensions ) {
                 symbol.setAttribute('height', height.toString());
                 symbol.setAttribute('width', width.toString());
             }

--- a/lib/index.js
+++ b/lib/index.js
@@ -173,6 +173,9 @@ module.exports = class SVGSpritemapPlugin {
                 }],  [{
                     name: 'cleanupIDs',
                     active: false // Force disable cleanupIDs as the identifiers are to be used to target a specific sprite
+                }], [{
+                    name: 'removeDimensions',
+                    active: !spriteOptions.generate.dimensions // Disable the removeDimensions plugin when dimensions should be generated
                 }]);
                 const output = svgo.optimize(assets[this.filenames.spritemap].source(), config);
 

--- a/lib/options-formatter.js
+++ b/lib/options-formatter.js
@@ -49,7 +49,8 @@ module.exports = (pattern, options) => {
                 title: true,
                 symbol: true,
                 use: false,
-                view: false
+                view: false,
+                keepDimensions: false,
             }
         },
         styles: false

--- a/lib/options-formatter.js
+++ b/lib/options-formatter.js
@@ -50,7 +50,7 @@ module.exports = (pattern, options) => {
                 symbol: true,
                 use: false,
                 view: false,
-                keepDimensions: false,
+                dimensions: false,
             }
         },
         styles: false

--- a/lib/options-validator.js
+++ b/lib/options-validator.js
@@ -58,7 +58,8 @@ module.exports = (pattern, options = {}) => {
                     view: Joi.alternatives([
                         Joi.boolean(),
                         Joi.string()
-                    ])
+                    ]),
+                    keepDimensions: Joi.boolean(),
                 })
             }),
             styles: Joi.alternatives([

--- a/lib/options-validator.js
+++ b/lib/options-validator.js
@@ -59,7 +59,7 @@ module.exports = (pattern, options = {}) => {
                         Joi.boolean(),
                         Joi.string()
                     ]),
-                    keepDimensions: Joi.boolean(),
+                    dimensions: Joi.boolean(),
                 })
             }),
             styles: Joi.alternatives([

--- a/tests/generate-svg.test.js
+++ b/tests/generate-svg.test.js
@@ -146,6 +146,25 @@ it('Generates with view tag when \'options.generate.view\' is `true`', async () 
     expect(svg).toEqual(output);
 });
 
+it('Keeps height and width attribute when \'sprite.generate.keepDimension\' option is `true`', async () => {
+    const output = fs.readFileSync(path.resolve(__dirname, 'output/svg/keep-dimensions.svg'), 'utf-8').trim();
+    const svg = await generateSVG([{
+        path: path.resolve(__dirname, 'input/svg/keep-dimensions.svg'),
+        content: fs.readFileSync(path.resolve(__dirname, 'input/svg/keep-dimensions.svg'), 'utf-8')
+    }], formatOptions({
+        output: {
+            svgo: false
+        },
+        sprite: {
+            generate: {
+                keepDimensions: true
+            },
+        }
+    }));
+
+    expect(svg).toEqual(output);
+});
+
 it('Adds the width and height attribute to the root SVG when required', async () => {
     const output = fs.readFileSync(path.resolve(__dirname, 'output/svg/sizes.svg'), 'utf-8').trim();
     const svg = await generateSVG([{
@@ -370,21 +389,4 @@ it('Should include spritemap inside generated chunk', (done) => {
         expect(chunk.files.has('spritemap.svg')).toBeTruthy();
         done();
     });
-});
-
-it('Keeps height and width attribute when \'sprite.generate.keepDimension\' option is `true`', async () => {
-    const output = fs.readFileSync(path.resolve(__dirname, 'output/svg/keep-dimensions.svg'), 'utf-8').trim();
-    const svg = await generateSVG([{
-        path: path.resolve(__dirname, 'input/svg/keep-dimensions.svg'),
-        content: fs.readFileSync(path.resolve(__dirname, 'input/svg/keep-dimensions.svg'), 'utf-8')
-    }], formatOptions({
-        output: {
-            svgo: false
-        },
-        sprite: {
-            generate: { keepDimension: true },
-        }
-    }));
-
-    expect(svg).toEqual(output);
 });

--- a/tests/generate-svg.test.js
+++ b/tests/generate-svg.test.js
@@ -157,7 +157,7 @@ it('Keeps height and width attribute when \'sprite.generate.keepDimension\' opti
         },
         sprite: {
             generate: {
-                keepDimensions: true
+                dimensions: true
             },
         }
     }));

--- a/tests/generate-svg.test.js
+++ b/tests/generate-svg.test.js
@@ -371,3 +371,20 @@ it('Should include spritemap inside generated chunk', (done) => {
         done();
     });
 });
+
+it('Keeps height and width attribute when \'sprite.generate.keepDimension\' option is `true`', async () => {
+    const output = fs.readFileSync(path.resolve(__dirname, 'output/svg/keep-dimensions.svg'), 'utf-8').trim();
+    const svg = await generateSVG([{
+        path: path.resolve(__dirname, 'input/svg/keep-dimensions.svg'),
+        content: fs.readFileSync(path.resolve(__dirname, 'input/svg/keep-dimensions.svg'), 'utf-8')
+    }], formatOptions({
+        output: {
+            svgo: false
+        },
+        sprite: {
+            generate: { keepDimension: true },
+        }
+    }));
+
+    expect(svg).toEqual(output);
+});

--- a/tests/input/svg/keep-dimensions.svg
+++ b/tests/input/svg/keep-dimensions.svg
@@ -1,0 +1,1 @@
+<svg viewBox="0 0 24 24" height="24" width="24" fill="red"><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/></svg>

--- a/tests/output/svg/keep-dimensions.svg
+++ b/tests/output/svg/keep-dimensions.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg"><symbol fill="red" id="sprite-keep-dimensions" viewBox="0 0 24 24" height="24" width="24"><title>sprite-keep-dimensions</title><path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/></symbol></svg>


### PR DESCRIPTION
### Issue
We are currently facing the issue that we need the original height and width attributes from the SVG on each symbol in our spritemap. This is needed because we want to place the symbol without adding the dimension manually and for each SVG.

**Input:**
```
<svg viewBox="0 0 24 24" height="24" width="24" fill="red">
    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/>
</svg>
```

**Output:**
```
<svg xmlns="http://www.w3.org/2000/svg">
    <symbol fill="red" id="sprite-keep-dimensions" viewBox="0 0 24 24">
        <title>sprite-keep-dimensions</title>
        <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/>
    </symbol>
</svg>
```

### Solution
I've added a new option `sprite.generate.keepDimensions` to the project, which if set to true, adds the dimensions to the symbol during its creation.

**Input:**
```
<svg viewBox="0 0 24 24" height="24" width="24" fill="red">
    <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/>
</svg>
```

**Output:**
```
<svg xmlns="http://www.w3.org/2000/svg">
    <symbol fill="red" id="sprite-keep-dimensions" viewBox="0 0 24 24" height="24" width="24">
        <title>sprite-keep-dimensions</title>
        <path d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"/>
    </symbol>
</svg>
```

### Changelog:
- added new option to `sprite.generate` for keeping SVG `height` and `width` attributes
- added test and SVGs for test
- added doc
