### PR TITLE
Fix broken input.allowDuplicates options

### DIFF
--- a/source/helpers/svg.ts
+++ b/source/helpers/svg.ts
@@ -18,7 +18,7 @@ import { Options } from '../types.js';
 export const SVG_PARSER = new xmldom.DOMParser();
 export const SVG_SERIALIZER = new xmldom.XMLSerializer();
 
-export const generateSVG = (sources: Record<string, string>, options: Options, warnings: webpack.WebpackError[]) => {
+export const generateSVG = (sources: Record<number, string[]>, options: Options, warnings: webpack.WebpackError[]) => {
     const sizes: Record<string, number[]> = {
         width: [],
         height: [],
@@ -31,7 +31,7 @@ export const generateSVG = (sources: Record<string, string>, options: Options, w
 
     const document = new xmldom.DOMImplementation().createDocument('http://www.w3.org/2000/svg', '');
     const svg = document.createElement('svg');
-    const items = compact(Object.entries(sources).map(([location, source]) => {
+    const items = compact(Object.entries(sources).map(([index, [location, source]]) => {
         return {
             location,
             id: generateIdentifier(location, options),

--- a/source/helpers/svg.ts
+++ b/source/helpers/svg.ts
@@ -31,7 +31,7 @@ export const generateSVG = (sources: Record<number, string[]>, options: Options,
 
     const document = new xmldom.DOMImplementation().createDocument('http://www.w3.org/2000/svg', '');
     const svg = document.createElement('svg');
-    const items = compact(Object.entries(sources).map(([index, [location, source]]) => {
+    const items = compact(Object.entries(sources).map(([, [location, source]]) => {
         return {
             location,
             id: generateIdentifier(location, options),

--- a/source/index.ts
+++ b/source/index.ts
@@ -23,7 +23,7 @@ import { Output, Options, Patterns, StylesType } from './types.js';
 class SVGSpritemapPlugin {
     patterns: Patterns;
     options: Options;
-    sources: Record<string, string> = {};
+    sources: Record<number, string[]> = {};
     warnings: webpack.WebpackError[] = [];
 
     filenames: Record<Output, string | undefined> = {
@@ -124,9 +124,9 @@ class SVGSpritemapPlugin {
             return;
         }
 
-        this.sources = Object.fromEntries(await Promise.all(this.dependencies.files.map(async (location) => {
-            return [location, await fs.promises.readFile(location, 'utf8')];
-        }))) as Record<string, string>;
+        this.sources = Object.fromEntries(await Promise.all(this.dependencies.files.map(async (location, index) => {
+            return [index, [location, await fs.promises.readFile(location, 'utf8')]];
+        }))) as Record<number, string[]>;
 
         if (!Object.keys(this.sources).length) {
             this.warnings.push(new webpack.WebpackError(`No SVG files found in the specified patterns: ${this.patterns.join(', ')}`));


### PR DESCRIPTION
Hello !

Once again, thanks you for this plugin. Me and my team are using it since 2021 and it's working like a charm !
For some context, you can see the following PR: https://github.com/cascornelissen/svg-spritemap-webpack-plugin/pull/172

I've update this plugin from 4.7.0 to the latest version and found out that the `input.allowDuplicates` options was broken.

After searching why, i found out that you are using `Object.entries()`. The problem is that with `allowDuplicates` we are using the same location, so the future object key are the same and they got "removed".

Example:
```javascript
const entries = [
  ["foo", "bar"],
  ["foo", 42],
];

console.log(Object.fromEntries(entries));
// Output: Object { foo: 42 }
```

I've update the code to add a key that will be unique (using `index` from `.map()`) and reflect this change wherever it was needed.
