### PR TITLE
Call idify only once

### DIFF
--- a/source/helpers/svg.ts
+++ b/source/helpers/svg.ts
@@ -32,10 +32,11 @@ export const generateSVG = (sources: Source[], options: Options, warnings: webpa
     const document = new xmldom.DOMImplementation().createDocument('http://www.w3.org/2000/svg', '');
     const svg = document.createElement('svg');
     const items = compact(sources.map((source) => {
+        const name = generateName(source.location, options);
         return {
             location: source.location,
-            id: generateIdentifier(source.location, options),
-            name: generateName(source.location, options),
+            id: generateIdentifier(source.location, options, name),
+            name,
             title: generateTitle(source.location),
             content: generateSprite(source.content)
         };
@@ -283,10 +284,10 @@ const generateName = (location: string, options: Options): string => {
     return options.sprite.idify(title);
 };
 
-const generateIdentifier = (location: string, options: Options) => {
+const generateIdentifier = (location: string, options: Options, name: string) => {
     return compact([
         generatePrefix(location, options),
-        generateName(location, options)
+        name
     ]).join('');
 };
 


### PR DESCRIPTION
Hello !

I found another issue for `allowDuplicates` user that wasn't easy to see at first.

When using `allowDuplicates`, you have to use `idify` to set a specific ID to the generated symbol. The problem is that the `idify` function is called **twice**.

With `allowDuplicates` you already receive multiple times the same "title" as `idify` parameter, so calling it twice makes it impossible to return a constant unique Id. 

I've updated the code to only call once the `idify` function.

